### PR TITLE
Thread issue fixes, reset vins fixes

### DIFF
--- a/vins_estimator/CMakeLists.txt
+++ b/vins_estimator/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(vins)
 
 set(CMAKE_BUILD_TYPE "Release")
+#set(CMAKE_BUILD_TYPE "Debug")
 set(CMAKE_CXX_FLAGS "-std=c++11")
 #-DEIGEN_USE_MKL_ALL")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
@@ -54,11 +55,10 @@ target_link_libraries(vins_lib ${catkin_LIBRARIES} ${OpenCV_LIBS} ${CERES_LIBRAR
 
 
 add_executable(vins_node src/rosNodeTest.cpp)
-target_link_libraries(vins_node vins_lib) 
+target_link_libraries(vins_node vins_lib)
 
 add_executable(kitti_odom_test src/KITTIOdomTest.cpp)
-target_link_libraries(kitti_odom_test vins_lib) 
+target_link_libraries(kitti_odom_test vins_lib)
 
 add_executable(kitti_gps_test src/KITTIGPSTest.cpp)
-target_link_libraries(kitti_gps_test vins_lib) 
-
+target_link_libraries(kitti_gps_test vins_lib)

--- a/vins_estimator/src/estimator/estimator.cpp
+++ b/vins_estimator/src/estimator/estimator.cpp
@@ -221,6 +221,8 @@ void Estimator::processMeasurements()
             curTime = feature.first + td;
             while(1)
             {
+                if( processThread_swt == false )
+                    break;
                 if ((!USE_IMU  || IMUAvailable(feature.first + td)))
                     break;
                 else

--- a/vins_estimator/src/estimator/estimator.cpp
+++ b/vins_estimator/src/estimator/estimator.cpp
@@ -114,7 +114,7 @@ void Estimator::inputImage(double t, const cv::Mat &_img, const cv::Mat &_img1)
         featureFrame = featureTracker.trackImage(t, _img);
     else
         featureFrame = featureTracker.trackImage(t, _img, _img1);
-    //printf("featureTracker time: %f\n", featureTrackerTime.toc());
+    printf("featureTracker time: %f, size=%d\n", featureTrackerTime.toc(), featureFrame.size() );
 
     if(MULTIPLE_THREAD)
     {
@@ -190,7 +190,7 @@ bool Estimator::getIMUInterval(double t0, double t1, vector<pair<double, Eigen::
     }
     else
     {
-        printf("wait for imu\n");
+        // printf("wait for imu\n");
         return false;
     }
     return true;
@@ -227,7 +227,7 @@ void Estimator::processMeasurements()
                     break;
                 else
                 {
-                    printf("wait for imu ... \n");
+                    // printf("wait for imu ... \n");
                     if (! MULTIPLE_THREAD)
                         return;
                     std::chrono::milliseconds dura(5);
@@ -258,7 +258,10 @@ void Estimator::processMeasurements()
                 }
             }
 
+            // mBuf.lock();
             processImage(feature.second, feature.first);
+            // mBuf.unlock();
+
             prevTime = curTime;
 
             printStatistics(*this, 0);
@@ -420,6 +423,7 @@ void Estimator::processImage(const map<int, vector<pair<int, Eigen::Matrix<doubl
     ROS_DEBUG("%s", marginalization_flag ? "Non-keyframe" : "Keyframe");
     ROS_DEBUG("Solving %d", frame_count);
     ROS_DEBUG("number of feature: %d", f_manager.getFeatureCount());
+    printf( "number of feature: %d\n", f_manager.getFeatureCount() );
     Headers[frame_count] = header;
 
     ImageFrame imageframe(image, header);

--- a/vins_estimator/src/estimator/estimator.cpp
+++ b/vins_estimator/src/estimator/estimator.cpp
@@ -1,8 +1,8 @@
 /*******************************************************
  * Copyright (C) 2019, Aerial Robotics Group, Hong Kong University of Science and Technology
- * 
+ *
  * This file is part of VINS.
- * 
+ *
  * Licensed under the GNU General Public License v3.0;
  * you may not use this file except in compliance with the License.
  *******************************************************/
@@ -14,6 +14,30 @@ Estimator::Estimator(): f_manager{Rs}
 {
     ROS_INFO("init begins");
     clearState();
+    clearVars();
+
+    // this is moved to function clearVars().
+    // prevTime = -1;
+    // curTime = 0;
+    // openExEstimation = 0;
+    // initP = Eigen::Vector3d(0, 0, 0);
+    // initR = Eigen::Matrix3d::Identity();
+    // inputImageCnt = 0;
+    // initFirstPoseFlag = false;
+}
+
+void Estimator::clearVars()
+{
+    mBuf.lock();
+    while( !accBuf.empty() )
+        accBuf.pop();
+    while( !gyrBuf.empty() )
+        gyrBuf.pop();
+    while( !featureBuf.empty() )
+        featureBuf.pop();
+    mBuf.unlock();
+
+
     prevTime = -1;
     curTime = 0;
     openExEstimation = 0;
@@ -47,6 +71,40 @@ void Estimator::setParameter()
     }
 }
 
+// this thread will not launch processMeasurements() thread.
+void Estimator::setParameterOnly()
+{
+    for (int i = 0; i < NUM_OF_CAM; i++)
+    {
+        tic[i] = TIC[i];
+        ric[i] = RIC[i];
+        cout << " exitrinsic cam " << i << endl  << ric[i] << endl << tic[i].transpose() << endl;
+    }
+    f_manager.setRic(ric);
+    ProjectionTwoFrameOneCamFactor::sqrt_info = FOCAL_LENGTH / 1.5 * Matrix2d::Identity();
+    ProjectionTwoFrameTwoCamFactor::sqrt_info = FOCAL_LENGTH / 1.5 * Matrix2d::Identity();
+    ProjectionOneFrameTwoCamFactor::sqrt_info = FOCAL_LENGTH / 1.5 * Matrix2d::Identity();
+    td = TD;
+    g = G;
+    cout << "set g " << g.transpose() << endl;
+    featureTracker.readIntrinsicParameter(CAM_NAMES);
+
+    // std::cout << "MULTIPLE_THREAD is " << MULTIPLE_THREAD << '\n';
+    // if (MULTIPLE_THREAD)
+    // {
+    //     processThread   = std::thread(&Estimator::processMeasurements, this);
+    // }
+}
+
+void Estimator::startProcessThread()
+{
+    std::cout << "MULTIPLE_THREAD is " << MULTIPLE_THREAD << '\n';
+    if (MULTIPLE_THREAD)
+    {
+        processThread   = std::thread(&Estimator::processMeasurements, this);
+    }
+}
+
 void Estimator::inputImage(double t, const cv::Mat &_img, const cv::Mat &_img1)
 {
     inputImageCnt++;
@@ -57,9 +115,9 @@ void Estimator::inputImage(double t, const cv::Mat &_img, const cv::Mat &_img1)
     else
         featureFrame = featureTracker.trackImage(t, _img, _img1);
     //printf("featureTracker time: %f\n", featureTrackerTime.toc());
-    
-    if(MULTIPLE_THREAD)  
-    {     
+
+    if(MULTIPLE_THREAD)
+    {
         if(inputImageCnt % 2 == 0)
         {
             mBuf.lock();
@@ -76,7 +134,7 @@ void Estimator::inputImage(double t, const cv::Mat &_img, const cv::Mat &_img1)
         processMeasurements();
         printf("process time: %f\n", processTime.toc());
     }
-    
+
 }
 
 void Estimator::inputIMU(double t, const Vector3d &linearAcceleration, const Vector3d &angularVelocity)
@@ -103,7 +161,7 @@ void Estimator::inputFeature(double t, const map<int, vector<pair<int, Eigen::Ma
 }
 
 
-bool Estimator::getIMUInterval(double t0, double t1, vector<pair<double, Eigen::Vector3d>> &accVector, 
+bool Estimator::getIMUInterval(double t0, double t1, vector<pair<double, Eigen::Vector3d>> &accVector,
                                 vector<pair<double, Eigen::Vector3d>> &gyrVector)
 {
     if(accBuf.empty())
@@ -148,9 +206,13 @@ bool Estimator::IMUAvailable(double t)
 
 void Estimator::processMeasurements()
 {
-    while (1)
+    cout << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n";
+    cout << "^^^^^ start thread processMeasurements ^^^^^^\n";
+    cout << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n";
+    // while (1)
+    while( processThread_swt )
     {
-        //printf("process measurments\n");
+        // printf("process measurments\n");
         pair<double, map<int, vector<pair<int, Eigen::Matrix<double, 7, 1> > > > > feature;
         vector<pair<double, Eigen::Vector3d>> accVector, gyrVector;
         if(!featureBuf.empty())
@@ -217,6 +279,10 @@ void Estimator::processMeasurements()
         std::chrono::milliseconds dura(2);
         std::this_thread::sleep_for(dura);
     }
+
+    cout << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n";
+    cout << "^^^^^ END  thread  processMeasurements ^^^^^^\n";
+    cout << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n";
 }
 
 
@@ -321,7 +387,7 @@ void Estimator::processIMU(double t, double dt, const Vector3d &linear_accelerat
         linear_acceleration_buf[frame_count].push_back(linear_acceleration);
         angular_velocity_buf[frame_count].push_back(angular_velocity);
 
-        int j = frame_count;         
+        int j = frame_count;
         Vector3d un_acc_0 = Rs[j] * (acc_0 - Bas[j]) - g;
         Vector3d un_gyr = 0.5 * (gyr_0 + angular_velocity) - Bgs[j];
         Rs[j] *= Utility::deltaQ(un_gyr * dt).toRotationMatrix();
@@ -331,7 +397,7 @@ void Estimator::processIMU(double t, double dt, const Vector3d &linear_accelerat
         Vs[j] += dt * un_acc;
     }
     acc_0 = linear_acceleration;
-    gyr_0 = angular_velocity; 
+    gyr_0 = angular_velocity;
 }
 
 void Estimator::processImage(const map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> &image, const double header)
@@ -388,7 +454,7 @@ void Estimator::processImage(const map<int, vector<pair<int, Eigen::Matrix<doubl
                 if(ESTIMATE_EXTRINSIC != 2 && (header - initial_timestamp) > 0.1)
                 {
                     result = initialStructure();
-                    initial_timestamp = header;   
+                    initial_timestamp = header;
                 }
                 if(result)
                 {
@@ -471,7 +537,7 @@ void Estimator::processImage(const map<int, vector<pair<int, Eigen::Matrix<doubl
             featureTracker.removeOutliers(removeIndex);
             predictPtsInNextFrame();
         }
-            
+
         ROS_DEBUG("solver costs: %fms", t_solve.toc());
 
         if (failureDetection())
@@ -496,7 +562,7 @@ void Estimator::processImage(const map<int, vector<pair<int, Eigen::Matrix<doubl
         last_R0 = Rs[0];
         last_P0 = Ps[0];
         updateLatestStates();
-    }  
+    }
 }
 
 bool Estimator::initialStructure()
@@ -548,7 +614,7 @@ bool Estimator::initialStructure()
             tmp_feature.observation.push_back(make_pair(imu_j, Eigen::Vector2d{pts_j.x(), pts_j.y()}));
         }
         sfm_f.push_back(tmp_feature);
-    } 
+    }
     Matrix3d relative_R;
     Vector3d relative_T;
     int l;
@@ -613,7 +679,7 @@ bool Estimator::initialStructure()
                 }
             }
         }
-        cv::Mat K = (cv::Mat_<double>(3, 3) << 1, 0, 0, 0, 1, 0, 0, 0, 1);     
+        cv::Mat K = (cv::Mat_<double>(3, 3) << 1, 0, 0, 0, 1, 0, 0, 0, 1);
         if(pts_3_vector.size() < 6)
         {
             cout << "pts_3_vector size " << pts_3_vector.size() << endl;
@@ -698,7 +764,7 @@ bool Estimator::visualInitialAlign()
         Vs[i] = rot_diff * Vs[i];
     }
     ROS_DEBUG_STREAM("g0     " << g.transpose());
-    ROS_DEBUG_STREAM("my R0  " << Utility::R2ypr(Rs[0]).transpose()); 
+    ROS_DEBUG_STREAM("my R0  " << Utility::R2ypr(Rs[0]).transpose());
 
     f_manager.clearDepth();
     f_manager.triangulate(frame_count, Ps, Rs, tic, ric);
@@ -820,7 +886,7 @@ void Estimator::double2vector()
         {
 
             Rs[i] = rot_diff * Quaterniond(para_Pose[i][6], para_Pose[i][3], para_Pose[i][4], para_Pose[i][5]).normalized().toRotationMatrix();
-            
+
             Ps[i] = rot_diff * Vector3d(para_Pose[i][0] - para_Pose[0][0],
                                     para_Pose[i][1] - para_Pose[0][1],
                                     para_Pose[i][2] - para_Pose[0][2]) + origin_P0;
@@ -837,7 +903,7 @@ void Estimator::double2vector()
                 Bgs[i] = Vector3d(para_SpeedBias[i][6],
                                   para_SpeedBias[i][7],
                                   para_SpeedBias[i][8]);
-            
+
         }
     }
     else
@@ -845,7 +911,7 @@ void Estimator::double2vector()
         for (int i = 0; i <= WINDOW_SIZE; i++)
         {
             Rs[i] = Quaterniond(para_Pose[i][6], para_Pose[i][3], para_Pose[i][4], para_Pose[i][5]).normalized().toRotationMatrix();
-            
+
             Ps[i] = Vector3d(para_Pose[i][0], para_Pose[i][1], para_Pose[i][2]);
         }
     }
@@ -908,7 +974,7 @@ bool Estimator::failureDetection()
     if (abs(tmp_P.z() - last_P.z()) > 1)
     {
         //ROS_INFO(" big z translation");
-        //return true; 
+        //return true;
     }
     Matrix3d tmp_R = Rs[WINDOW_SIZE];
     Matrix3d delta_R = tmp_R.transpose() * last_R;
@@ -990,11 +1056,11 @@ void Estimator::optimization()
         it_per_id.used_num = it_per_id.feature_per_frame.size();
         if (it_per_id.used_num < 4)
             continue;
- 
+
         ++feature_index;
 
         int imu_i = it_per_id.start_frame, imu_j = imu_i - 1;
-        
+
         Vector3d pts_i = it_per_id.feature_per_frame[0].point;
 
         for (auto &it_per_frame : it_per_id.feature_per_frame)
@@ -1009,7 +1075,7 @@ void Estimator::optimization()
             }
 
             if(STEREO && it_per_frame.is_stereo)
-            {                
+            {
                 Vector3d pts_j_right = it_per_frame.pointRight;
                 if(imu_i != imu_j)
                 {
@@ -1023,7 +1089,7 @@ void Estimator::optimization()
                                                                  it_per_id.feature_per_frame[0].cur_td, it_per_frame.cur_td);
                     problem.AddResidualBlock(f, loss_function, para_Ex_Pose[0], para_Ex_Pose[1], para_Feature[feature_index], para_Td[0]);
                 }
-               
+
             }
             f_m_cnt++;
         }
@@ -1151,7 +1217,7 @@ void Estimator::optimization()
         TicToc t_pre_margin;
         marginalization_info->preMarginalize();
         ROS_DEBUG("pre marginalization %f ms", t_pre_margin.toc());
-        
+
         TicToc t_margin;
         marginalization_info->marginalize();
         ROS_DEBUG("marginalization %f ms", t_margin.toc());
@@ -1174,7 +1240,7 @@ void Estimator::optimization()
             delete last_marginalization_info;
         last_marginalization_info = marginalization_info;
         last_marginalization_parameter_blocks = parameter_blocks;
-        
+
     }
     else
     {
@@ -1211,7 +1277,7 @@ void Estimator::optimization()
             ROS_DEBUG("begin marginalization");
             marginalization_info->marginalize();
             ROS_DEBUG("end marginalization, %f ms", t_margin.toc());
-            
+
             std::unordered_map<long, double *> addr_shift;
             for (int i = 0; i <= WINDOW_SIZE; i++)
             {
@@ -1235,13 +1301,13 @@ void Estimator::optimization()
 
             addr_shift[reinterpret_cast<long>(para_Td[0])] = para_Td[0];
 
-            
+
             vector<double *> parameter_blocks = marginalization_info->getParameterBlocks(addr_shift);
             if (last_marginalization_info)
                 delete last_marginalization_info;
             last_marginalization_info = marginalization_info;
             last_marginalization_parameter_blocks = parameter_blocks;
-            
+
         }
     }
     //printf("whole marginalization costs: %f \n", t_whole_marginalization.toc());
@@ -1419,7 +1485,7 @@ void Estimator::predictPtsInNextFrame()
 }
 
 double Estimator::reprojectionError(Matrix3d &Ri, Vector3d &Pi, Matrix3d &rici, Vector3d &tici,
-                                 Matrix3d &Rj, Vector3d &Pj, Matrix3d &ricj, Vector3d &ticj, 
+                                 Matrix3d &Rj, Vector3d &Pj, Matrix3d &ricj, Vector3d &ticj,
                                  double depth, Vector3d &uvi, Vector3d &uvj)
 {
     Vector3d pts_w = Ri * (rici * (depth * uvi) + tici) + Pi;
@@ -1450,8 +1516,8 @@ void Estimator::outliersRejection(set<int> &removeIndex)
             imu_j++;
             if (imu_i != imu_j)
             {
-                Vector3d pts_j = it_per_frame.point;             
-                double tmp_error = reprojectionError(Rs[imu_i], Ps[imu_i], ric[0], tic[0], 
+                Vector3d pts_j = it_per_frame.point;
+                double tmp_error = reprojectionError(Rs[imu_i], Ps[imu_i], ric[0], tic[0],
                                                     Rs[imu_j], Ps[imu_j], ric[0], tic[0],
                                                     depth, pts_i, pts_j);
                 err += tmp_error;
@@ -1461,11 +1527,11 @@ void Estimator::outliersRejection(set<int> &removeIndex)
             // need to rewrite projecton factor.........
             if(STEREO && it_per_frame.is_stereo)
             {
-                
+
                 Vector3d pts_j_right = it_per_frame.pointRight;
                 if(imu_i != imu_j)
-                {            
-                    double tmp_error = reprojectionError(Rs[imu_i], Ps[imu_i], ric[0], tic[0], 
+                {
+                    double tmp_error = reprojectionError(Rs[imu_i], Ps[imu_i], ric[0], tic[0],
                                                         Rs[imu_j], Ps[imu_j], ric[1], tic[1],
                                                         depth, pts_i, pts_j_right);
                     err += tmp_error;
@@ -1474,13 +1540,13 @@ void Estimator::outliersRejection(set<int> &removeIndex)
                 }
                 else
                 {
-                    double tmp_error = reprojectionError(Rs[imu_i], Ps[imu_i], ric[0], tic[0], 
+                    double tmp_error = reprojectionError(Rs[imu_i], Ps[imu_i], ric[0], tic[0],
                                                         Rs[imu_j], Ps[imu_j], ric[1], tic[1],
                                                         depth, pts_i, pts_j_right);
                     err += tmp_error;
                     errCnt++;
                     //printf("tmp_error %f\n", FOCAL_LENGTH / 1.5 * tmp_error);
-                }       
+                }
             }
         }
         double ave_err = err / errCnt;

--- a/vins_estimator/src/estimator/estimator.h
+++ b/vins_estimator/src/estimator/estimator.h
@@ -1,16 +1,17 @@
 /*******************************************************
  * Copyright (C) 2019, Aerial Robotics Group, Hong Kong University of Science and Technology
- * 
+ *
  * This file is part of VINS.
- * 
+ *
  * Licensed under the GNU General Public License v3.0;
  * you may not use this file except in compliance with the License.
  *******************************************************/
 
 #pragma once
- 
+
 #include <thread>
 #include <mutex>
+#include <atomic>
 #include <std_msgs/Header.h>
 #include <std_msgs/Float32.h>
 #include <ceres/ceres.h>
@@ -44,6 +45,12 @@ class Estimator
 
     void setParameter();
 
+    void setParameterOnly();
+    void startProcessThread();
+    void clearVars();
+
+
+
     // interface
     void initFirstPose(Eigen::Vector3d p, Eigen::Matrix3d r);
     void inputIMU(double t, const Vector3d &linearAcceleration, const Vector3d &angularVelocity);
@@ -65,14 +72,14 @@ class Estimator
     void vector2double();
     void double2vector();
     bool failureDetection();
-    bool getIMUInterval(double t0, double t1, vector<pair<double, Eigen::Vector3d>> &accVector, 
+    bool getIMUInterval(double t0, double t1, vector<pair<double, Eigen::Vector3d>> &accVector,
                                               vector<pair<double, Eigen::Vector3d>> &gyrVector);
     void getPoseInWorldFrame(Eigen::Matrix4d &T);
     void getPoseInWorldFrame(int index, Eigen::Matrix4d &T);
     void predictPtsInNextFrame();
     void outliersRejection(set<int> &removeIndex);
     double reprojectionError(Matrix3d &Ri, Vector3d &Pi, Matrix3d &rici, Vector3d &tici,
-                                     Matrix3d &Rj, Vector3d &Pj, Matrix3d &ricj, Vector3d &ticj, 
+                                     Matrix3d &Rj, Vector3d &Pj, Matrix3d &ricj, Vector3d &ticj,
                                      double depth, Vector3d &uvi, Vector3d &uvj);
     void updateLatestStates();
     void fastPredictIMU(double t, Eigen::Vector3d linear_acceleration, Eigen::Vector3d angular_velocity);
@@ -98,8 +105,9 @@ class Estimator
     double prevTime, curTime;
     bool openExEstimation;
 
-    std::thread trackThread;
+    std::thread trackThread; //< not in use currently
     std::thread processThread;
+    atomic<bool> processThread_swt; //< this goes in while(1) aka inf-while of processThread
 
     FeatureTracker featureTracker;
 

--- a/vins_estimator/src/featureTracker/feature_tracker.cpp
+++ b/vins_estimator/src/featureTracker/feature_tracker.cpp
@@ -1,8 +1,8 @@
 /*******************************************************
  * Copyright (C) 2019, Aerial Robotics Group, Hong Kong University of Science and Technology
- * 
+ *
  * This file is part of VINS.
- * 
+ *
  * Licensed under the GNU General Public License v3.0;
  * you may not use this file except in compliance with the License.
  *
@@ -109,14 +109,14 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
     row = cur_img.rows;
     col = cur_img.cols;
     cv::Mat rightImg = _img1;
-    /*
+
     {
         cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE(3.0, cv::Size(8, 8));
         clahe->apply(cur_img, cur_img);
         if(!rightImg.empty())
             clahe->apply(rightImg, rightImg);
     }
-    */
+    
     cur_pts.clear();
 
     if (prev_pts.size() > 0)
@@ -127,9 +127,9 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
         if(hasPrediction)
         {
             cur_pts = predict_pts;
-            cv::calcOpticalFlowPyrLK(prev_img, cur_img, prev_pts, cur_pts, status, err, cv::Size(21, 21), 1, 
+            cv::calcOpticalFlowPyrLK(prev_img, cur_img, prev_pts, cur_pts, status, err, cv::Size(21, 21), 1,
             cv::TermCriteria(cv::TermCriteria::COUNT+cv::TermCriteria::EPS, 30, 0.01), cv::OPTFLOW_USE_INITIAL_FLOW);
-            
+
             int succ_num = 0;
             for (size_t i = 0; i < status.size(); i++)
             {
@@ -146,9 +146,9 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
         {
             vector<uchar> reverse_status;
             vector<cv::Point2f> reverse_pts = prev_pts;
-            cv::calcOpticalFlowPyrLK(cur_img, prev_img, cur_pts, reverse_pts, reverse_status, err, cv::Size(21, 21), 1, 
+            cv::calcOpticalFlowPyrLK(cur_img, prev_img, cur_pts, reverse_pts, reverse_status, err, cv::Size(21, 21), 1,
             cv::TermCriteria(cv::TermCriteria::COUNT+cv::TermCriteria::EPS, 30, 0.01), cv::OPTFLOW_USE_INITIAL_FLOW);
-            //cv::calcOpticalFlowPyrLK(cur_img, prev_img, cur_pts, reverse_pts, reverse_status, err, cv::Size(21, 21), 3); 
+            //cv::calcOpticalFlowPyrLK(cur_img, prev_img, cur_pts, reverse_pts, reverse_status, err, cv::Size(21, 21), 3);
             for(size_t i = 0; i < status.size(); i++)
             {
                 if(status[i] && reverse_status[i] && distance(prev_pts[i], reverse_pts[i]) <= 0.5)
@@ -159,7 +159,7 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
                     status[i] = 0;
             }
         }
-        
+
         for (int i = 0; i < int(cur_pts.size()); i++)
             if (status[i] && !inBorder(cur_pts[i]))
                 status[i] = 0;
@@ -408,7 +408,7 @@ vector<cv::Point2f> FeatureTracker::undistortedPts(vector<cv::Point2f> &pts, cam
     return un_pts;
 }
 
-vector<cv::Point2f> FeatureTracker::ptsVelocity(vector<int> &ids, vector<cv::Point2f> &pts, 
+vector<cv::Point2f> FeatureTracker::ptsVelocity(vector<int> &ids, vector<cv::Point2f> &pts,
                                             map<int, cv::Point2f> &cur_id_pts, map<int, cv::Point2f> &prev_id_pts)
 {
     vector<cv::Point2f> pts_velocity;
@@ -422,7 +422,7 @@ vector<cv::Point2f> FeatureTracker::ptsVelocity(vector<int> &ids, vector<cv::Poi
     if (!prev_id_pts.empty())
     {
         double dt = cur_time - prev_time;
-        
+
         for (unsigned int i = 0; i < pts.size(); i++)
         {
             std::map<int, cv::Point2f>::iterator it;
@@ -448,9 +448,9 @@ vector<cv::Point2f> FeatureTracker::ptsVelocity(vector<int> &ids, vector<cv::Poi
     return pts_velocity;
 }
 
-void FeatureTracker::drawTrack(const cv::Mat &imLeft, const cv::Mat &imRight, 
+void FeatureTracker::drawTrack(const cv::Mat &imLeft, const cv::Mat &imRight,
                                vector<int> &curLeftIds,
-                               vector<cv::Point2f> &curLeftPts, 
+                               vector<cv::Point2f> &curLeftPts,
                                vector<cv::Point2f> &curRightPts,
                                map<int, cv::Point2f> &prevLeftPtsMap)
 {
@@ -478,7 +478,7 @@ void FeatureTracker::drawTrack(const cv::Mat &imLeft, const cv::Mat &imRight,
             //cv::line(imTrack, leftPt, rightPt, cv::Scalar(0, 255, 0), 1, 8, 0);
         }
     }
-    
+
     map<int, cv::Point2f>::iterator mapIt;
     for (size_t i = 0; i < curLeftIds.size(); i++)
     {

--- a/vins_estimator/src/featureTracker/feature_tracker.cpp
+++ b/vins_estimator/src/featureTracker/feature_tracker.cpp
@@ -111,12 +111,13 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
     cv::Mat rightImg = _img1;
 
     {
-        cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE(3.0, cv::Size(8, 8));
+        cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE(18.0, cv::Size(8, 8));
+        // cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
         clahe->apply(cur_img, cur_img);
         if(!rightImg.empty())
             clahe->apply(rightImg, rightImg);
     }
-    
+
     cur_pts.clear();
 
     if (prev_pts.size() > 0)
@@ -138,6 +139,9 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
             }
             if (succ_num < 10)
                cv::calcOpticalFlowPyrLK(prev_img, cur_img, prev_pts, cur_pts, status, err, cv::Size(21, 21), 3);
+
+           printf("succ_num %d\n", (int)succ_num);
+
         }
         else
             cv::calcOpticalFlowPyrLK(prev_img, cur_img, prev_pts, cur_pts, status, err, cv::Size(21, 21), 3);
@@ -168,7 +172,7 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
         reduceVector(ids, status);
         reduceVector(track_cnt, status);
         ROS_DEBUG("temporal optical flow costs: %fms", t_o.toc());
-        //printf("track cnt %d\n", (int)ids.size());
+        printf("track cnt %d\n", (int)ids.size());
     }
 
     for (auto &n : track_cnt)

--- a/vins_estimator/src/rosNodeTest.cpp
+++ b/vins_estimator/src/rosNodeTest.cpp
@@ -64,13 +64,14 @@ int bnd = 0; // how many times in `if` and looks like unkidnapped
 void img0_callback(const sensor_msgs::ImageConstPtr &img_msg)
 {
     if( rcvd_tracked_feature == false ) {
-        ROS_INFO( "[img0_callback] Ignoring Tracked Features" );
 
 
         // continue publishing /vins_estimator/keyframe_point.
         knd++;
-        if( knd%10 != 0 )
+        if( knd%5 != 0 )
             return;
+
+        ROS_INFO( "[img0_callback] Ignoring Tracked Features" );
         // fake_publish( 20 );
         cv::Mat ximage0 = getImageFromMsg(img_msg);
         // cv::Scalar ans = cv::mean( ximage0 );
@@ -91,8 +92,8 @@ void img0_callback(const sensor_msgs::ImageConstPtr &img_msg)
             return;
         }
         if( cnd > 10 ) {
-            fake_publish(img_msg->header, 20);
-            return ;
+            // fake_publish(img_msg->header, 10);
+            // return ;
         }
 
 
@@ -357,6 +358,7 @@ int main(int argc, char **argv)
 
     estimator.processThread_swt = false;
     estimator.processThread.join();
+    sync_thread.join();
 
     return 0;
 }

--- a/vins_estimator/src/rosNodeTest.cpp
+++ b/vins_estimator/src/rosNodeTest.cpp
@@ -34,29 +34,6 @@ std::mutex m_buf;
 bool rcvd_tracked_feature = true;
 bool rcvd_imu_msg = true;
 
-void img0_callback(const sensor_msgs::ImageConstPtr &img_msg)
-{
-    if( rcvd_tracked_feature == false ) {
-        // ROS_INFO( "[img0_callback] Ignoring Tracked Features" );
-        return;
-    }
-
-    m_buf.lock();
-    img0_buf.push(img_msg);
-    m_buf.unlock();
-}
-
-void img1_callback(const sensor_msgs::ImageConstPtr &img_msg)
-{
-    if( rcvd_tracked_feature == false ) {
-        // ROS_INFO( "[img1_callback] Ignoring Tracked Features" );
-        return;
-    }
-
-    m_buf.lock();
-    img1_buf.push(img_msg);
-    m_buf.unlock();
-}
 
 
 cv::Mat getImageFromMsg(const sensor_msgs::ImageConstPtr &img_msg)
@@ -80,6 +57,67 @@ cv::Mat getImageFromMsg(const sensor_msgs::ImageConstPtr &img_msg)
     cv::Mat img = ptr->image.clone();
     return img;
 }
+
+int knd = 0; // how many times inside `if`
+int cnd = 0; // how many times kidnapped (mean is low and std dev is low)
+int bnd = 0; // how many times in `if` and looks like unkidnapped
+void img0_callback(const sensor_msgs::ImageConstPtr &img_msg)
+{
+    if( rcvd_tracked_feature == false ) {
+        ROS_INFO( "[img0_callback] Ignoring Tracked Features" );
+
+
+        // continue publishing /vins_estimator/keyframe_point.
+        knd++;
+        if( knd%10 != 0 )
+            return;
+        // fake_publish( 20 );
+        cv::Mat ximage0 = getImageFromMsg(img_msg);
+        // cv::Scalar ans = cv::mean( ximage0 );
+        // cout << ans << endl;
+
+        cv::Scalar xmean, xstd;
+        cv::meanStdDev( ximage0, xmean, xstd );
+        cout << "xmean: " << xmean[0] << "\t" << "xstd: "  << xstd[0] << endl;;
+
+
+        if( xmean[0] < 35. && xstd[0] < 15. )
+            cnd++;
+        else
+            bnd++;
+
+        if( bnd > 10 ) {
+            fake_publish(img_msg->header, 100);
+            return;
+        }
+        if( cnd > 10 ) {
+            fake_publish(img_msg->header, 20);
+            return ;
+        }
+
+
+        return;
+    }
+
+    cnd = 0; knd=0; bnd=0;
+    m_buf.lock();
+    img0_buf.push(img_msg);
+    m_buf.unlock();
+}
+
+void img1_callback(const sensor_msgs::ImageConstPtr &img_msg)
+{
+    if( rcvd_tracked_feature == false ) {
+        // ROS_INFO( "[img1_callback] Ignoring Tracked Features" );
+        return;
+    }
+
+    m_buf.lock();
+    img1_buf.push(img_msg);
+    m_buf.unlock();
+}
+
+
 
 // extract images with same timestamp from two topics
 void sync_process()
@@ -263,7 +301,7 @@ void rcvd_inputs_callback( const std_msgs::BoolConstPtr& rcvd_ ) {
 
         ROS_INFO( "all the queues have been emptied");
         estimator.clearState();
-        estimator.clearVars(); 
+        estimator.clearVars();
         return;
     }
 

--- a/vins_estimator/src/utility/visualization.cpp
+++ b/vins_estimator/src/utility/visualization.cpp
@@ -1,8 +1,8 @@
 /*******************************************************
  * Copyright (C) 2019, Aerial Robotics Group, Hong Kong University of Science and Technology
- * 
+ *
  * This file is part of VINS.
- * 
+ *
  * Licensed under the GNU General Public License v3.0;
  * you may not use this file except in compliance with the License.
  *******************************************************/
@@ -28,6 +28,21 @@ static double sum_of_path = 0;
 static Vector3d last_path(0.0, 0.0, 0.0);
 
 size_t pub_counter = 0;
+
+// added my mpkuse
+void fake_publish( const std_msgs::Header &header, int n ) {
+    cout << "*******fake_publish(" << n << ")\n";
+    sensor_msgs::PointCloud x;
+    x.header = header; 
+
+    for( int i=0 ; i<n ; i++ ) {
+        geometry_msgs::Point32 pt;
+        pt.x=0.0; pt.y=0.0; pt.z=0.0;
+        x.points.push_back( pt );
+    }
+
+    pub_keyframe_point.publish(x );
+}
 
 void registerPub(ros::NodeHandle &n)
 {
@@ -265,7 +280,7 @@ void pubPointCloud(const Estimator &estimator, const std_msgs::Header &header)
     margin_cloud.header = header;
 
     for (auto &it_per_id : estimator.f_manager.feature)
-    { 
+    {
         int used_num;
         used_num = it_per_id.feature_per_frame.size();
         if (!(used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
@@ -273,7 +288,7 @@ void pubPointCloud(const Estimator &estimator, const std_msgs::Header &header)
         //if (it_per_id->start_frame > WINDOW_SIZE * 3.0 / 4.0 || it_per_id->solve_flag != 1)
         //        continue;
 
-        if (it_per_id.start_frame == 0 && it_per_id.feature_per_frame.size() <= 2 
+        if (it_per_id.start_frame == 0 && it_per_id.feature_per_frame.size() <= 2
             && it_per_id.solve_flag == 1 )
         {
             int imu_i = it_per_id.start_frame;
@@ -325,7 +340,7 @@ void pubTF(const Estimator &estimator, const std_msgs::Header &header)
     transform.setRotation(q);
     br.sendTransform(tf::StampedTransform(transform, header.stamp, "body", "camera"));
 
-    
+
     nav_msgs::Odometry odometry;
     odometry.header = header;
     odometry.header.frame_id = "world";

--- a/vins_estimator/src/utility/visualization.h
+++ b/vins_estimator/src/utility/visualization.h
@@ -1,8 +1,8 @@
 /*******************************************************
  * Copyright (C) 2019, Aerial Robotics Group, Hong Kong University of Science and Technology
- * 
+ *
  * This file is part of VINS.
- * 
+ *
  * Licensed under the GNU General Public License v3.0;
  * you may not use this file except in compliance with the License.
  *******************************************************/
@@ -37,6 +37,8 @@ extern ros::Publisher pub_key;
 extern nav_msgs::Path path;
 extern ros::Publisher pub_pose_graph;
 extern int IMAGE_ROW, IMAGE_COL;
+
+void fake_publish( const std_msgs::Header &header, int n ); //< added by mpkuse
 
 void registerPub(ros::NodeHandle &n);
 


### PR DESCRIPTION
Summary of my changes which don't affect the core functionality : 
a. The current implementation doesn't join the threads which potentially creates orphan threads. I have fixed this, see changes in rosTest.cpp 
b. Implemented and verified vins reset mechanism. vins_estimator subscribes to Bool message and if that bool is false vins_estimator is switched off. Look at the comments in rosTest.cpp/rcvd_inputs_callback(). Also look at comments in other callbacks. 

Changes that affect core functionality
c. image equalization see vins_estimator/src/featureTracker/feature_tracker.cpp 