### PR TITLE
Fix undefined behaviour in Estimator::clearState()

### DIFF
--- a/vins_estimator/src/estimator/estimator.h
+++ b/vins_estimator/src/estimator/estimator.h
@@ -123,7 +123,7 @@ class Estimator
     Vector3d back_P0, last_P, last_P0;
     double Headers[(WINDOW_SIZE + 1)];
 
-    IntegrationBase *pre_integrations[(WINDOW_SIZE + 1)];
+    IntegrationBase *pre_integrations[(WINDOW_SIZE + 1)] = {};
     Vector3d acc_0, gyr_0;
 
     vector<double> dt_buf[(WINDOW_SIZE + 1)];
@@ -158,11 +158,11 @@ class Estimator
 
     int loop_window_index;
 
-    MarginalizationInfo *last_marginalization_info;
+    MarginalizationInfo *last_marginalization_info = nullptr;
     vector<double *> last_marginalization_parameter_blocks;
 
     map<double, ImageFrame> all_image_frame;
-    IntegrationBase *tmp_pre_integration;
+    IntegrationBase *tmp_pre_integration = nullptr;
 
     Eigen::Vector3d initP;
     Eigen::Matrix3d initR;


### PR DESCRIPTION
In class `Estimator`:
`pre_integrations,` `last_marginalization_info`, `tmp_pre_integration` are not initialized. 
Because `clearState()` is called in Estimator's constructor and uses these variables, it's undefined behavior.