### PR TITLE
allow calibration to capture images from a rostopic

### DIFF
--- a/camera_models/CMakeLists.txt
+++ b/camera_models/CMakeLists.txt
@@ -7,8 +7,11 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fPIC")
 
 find_package(catkin REQUIRED COMPONENTS
     roscpp
+    image_transport
+    cv_bridge
     std_msgs
-    )
+    sensor_msgs
+)
 
 find_package(Boost REQUIRED COMPONENTS filesystem program_options system)
 include_directories(${Boost_INCLUDE_DIRS})
@@ -64,5 +67,5 @@ add_library(camera_models
     src/gpl/gpl.cc
     src/gpl/EigenQuaternionParameterization.cc)
 
-target_link_libraries(Calibrations ${Boost_LIBRARIES} ${OpenCV_LIBS} ${CERES_LIBRARIES})
+target_link_libraries(Calibrations ${Boost_LIBRARIES} ${OpenCV_LIBS} ${CERES_LIBRARIES} ${catkin_LIBRARIES})
 target_link_libraries(camera_models ${Boost_LIBRARIES} ${OpenCV_LIBS} ${CERES_LIBRARIES})


### PR DESCRIPTION
good for quickly/easily creating the calibration dataset.

Add the `--capture` flag to bring up a window showing the live feed. Pressing space will capture an image and put it in the specified directory (via `-i`). Pressing escape will continue with the calibration.

For example:
```bash
rosrun camera_models Calibrations -v -w 9 -h 6 -s 23 -i mycam \
               -p "left-" --camera-name "mycam_left" --capture \
               --camera-model mei image:=/camera/image_raw
```