### PR TITLE
Fix typos in "Monocular"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Download [EuRoC MAV Dataset](http://projects.asl.ethz.ch/datasets/doku.php?id=km
 Open four terminals, run vins odometry, visual loop closure(optional), rviz and play the bag file respectively. 
 Green path is VIO odometry; red path is odometry under visual loop closure.
 
-### 3.1 Monocualr camera + IMU
+### 3.1 Monocular camera + IMU
 
 ```
     roslaunch vins vins_rviz.launch
@@ -146,7 +146,7 @@ make build
 Note that the docker building process may take a while depends on your network and machine. After VINS-Fusion successfully built, you can run vins estimator with script `run.sh`.
 Script `run.sh` can take several flags and arguments. Flag `-k` means KITTI, `-l` represents loop fusion, and `-g` stands for global fusion. You can get the usage details by `./run.sh -h`. Here are some examples with this script:
 ```
-# Euroc Monocualr camera + IMU
+# Euroc Monocular camera + IMU
 ./run.sh ~/catkin_ws/src/VINS-Fusion/config/euroc/euroc_mono_imu_config.yaml
 
 # Euroc Stereo cameras + IMU with loop fusion


### PR DESCRIPTION
A tiny fix. Two words had a spelling mistake where "monocular" was not spelled correctly.