### PR TITLE
adding a NaN check for feature points 

### DIFF
--- a/vins_estimator/src/featureTracker/feature_tracker.cpp
+++ b/vins_estimator/src/featureTracker/feature_tracker.cpp
@@ -260,6 +260,8 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
     map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> featureFrame;
     for (size_t i = 0; i < ids.size(); i++)
     {
+      if(!std::isnan(cur_un_pts[i].x) && !std::isnan(cur_un_pts[i].y))
+      {
         int feature_id = ids[i];
         double x, y ,z;
         x = cur_un_pts[i].x;
@@ -276,12 +278,15 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
         Eigen::Matrix<double, 7, 1> xyz_uv_velocity;
         xyz_uv_velocity << x, y, z, p_u, p_v, velocity_x, velocity_y;
         featureFrame[feature_id].emplace_back(camera_id,  xyz_uv_velocity);
+      }
     }
 
     if (!_img1.empty() && stereo_cam)
     {
         for (size_t i = 0; i < ids_right.size(); i++)
         {
+          if(!std::isnan(cur_un_right_pts[i].x) && !std::isnan(cur_un_right_pts[i].y))
+          {
             int feature_id = ids_right[i];
             double x, y ,z;
             x = cur_un_right_pts[i].x;
@@ -298,6 +303,7 @@ map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> FeatureTracker::trackIm
             Eigen::Matrix<double, 7, 1> xyz_uv_velocity;
             xyz_uv_velocity << x, y, z, p_u, p_v, velocity_x, velocity_y;
             featureFrame[feature_id].emplace_back(camera_id,  xyz_uv_velocity);
+          }
         }
     }
 


### PR DESCRIPTION
Adding a nan check for feature points in feature tracker which is causing problems with fisheye lens cameras like the Intel Realsense T265. I have checked the working of the algorithm as it works fine now with the default calibration parameter provided by intel. 