### PR TITLE
Fix build error on Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Download [EuRoC MAV Dataset](http://projects.asl.ethz.ch/datasets/doku.php?id=km
 Open four terminals, run vins odometry, visual loop closure(optional), rviz and play the bag file respectively. 
 Green path is VIO odometry; red path is odometry under visual loop closure.
 
-### 3.1 Monocualr camera + IMU
+### 3.1 Monocular camera + IMU
 
 ```
     roslaunch vins vins_rviz.launch

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Follow [Ceres Installation](http://ceres-solver.org/installation.html).
 ## 2. Build VINS-Fusion
 Clone the repository and catkin_make:
 ```
+    mkdir -p ~/catkin_ws/src
     cd ~/catkin_ws/src
     git clone https://github.com/HKUST-Aerial-Robotics/VINS-Fusion.git
     cd ../

--- a/camera_models/include/camodocal/calib/CameraCalibration.h
+++ b/camera_models/include/camodocal/calib/CameraCalibration.h
@@ -2,6 +2,9 @@
 #define CAMERACALIBRATION_H
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs/legacy/constants_c.h>
+#include <opencv2/imgproc/types_c.h>
+#include <opencv2/imgproc/imgproc_c.h>
 
 #include "camodocal/camera_models/Camera.h"
 

--- a/camera_models/include/camodocal/camera_models/Camera.h
+++ b/camera_models/include/camodocal/camera_models/Camera.h
@@ -4,6 +4,9 @@
 #include <boost/shared_ptr.hpp>
 #include <eigen3/Eigen/Dense>
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs/legacy/constants_c.h>
+#include <opencv2/imgproc/types_c.h>
+#include <opencv2/imgproc/imgproc_c.h>
 #include <vector>
 
 namespace camodocal

--- a/camera_models/include/camodocal/chessboard/Chessboard.h
+++ b/camera_models/include/camodocal/chessboard/Chessboard.h
@@ -3,6 +3,10 @@
 
 #include <boost/shared_ptr.hpp>
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs/legacy/constants_c.h>
+#include <opencv2/imgproc/types_c.h>
+#include <opencv2/imgproc/imgproc_c.h>
+#include <opencv2/calib3d/calib3d_c.h>
 
 namespace camodocal
 {

--- a/loop_fusion/src/ThirdParty/DVision/BRIEF.h
+++ b/loop_fusion/src/ThirdParty/DVision/BRIEF.h
@@ -30,6 +30,7 @@
 #define __D_BRIEF__
 
 #include <opencv2/opencv.hpp>
+#include <opencv2/imgproc/imgproc_c.h>
 #include <vector>
 #include <boost/dynamic_bitset.hpp>
 


### PR DESCRIPTION
I tried the last version of this code but faced with build error. It's because of version of OpenCV which is installed with ROS Noetic. with these changes there won't be any build error and you can use VINS-Fusion on Ubuntu 20.04 and ROS Noetic.