### PR TITLE
improve/opencv version check

### DIFF
--- a/camera_models/CMakeLists.txt
+++ b/camera_models/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Boost REQUIRED COMPONENTS filesystem program_options system)
 include_directories(${Boost_INCLUDE_DIRS})
 
-find_package(OpenCV REQUIRED)
+find_package(OpenCV 3.4.2 REQUIRED)
 
 # set(EIGEN_INCLUDE_DIR "/usr/local/include/eigen3")
 find_package(Ceres REQUIRED)

--- a/loop_fusion/CMakeLists.txt
+++ b/loop_fusion/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
     roslib
     )
 
-find_package(OpenCV)
+find_package(OpenCV 3.4.2 REQUIRED)
 
 
 find_package(Ceres REQUIRED)

--- a/vins_estimator/CMakeLists.txt
+++ b/vins_estimator/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
     camera_models
     image_transport)
 
-find_package(OpenCV REQUIRED)
+find_package(OpenCV 3.4.2 REQUIRED)
 
 # message(WARNING "OpenCV_VERSION: ${OpenCV_VERSION}")
 


### PR DESCRIPTION
this pr is trying to fix the make error:`Undefined Reference to cv::Mat::updateContinuityFlag()` since this repo used this function provided by OpenCV 3.4.2 and later

- make error:
`Undefined Reference to cv::Mat::updateContinuityFlag()`

- refitem:
https://docs.opencv.org/3.4.2/d3/d63/classcv_1_1Mat.html#a3520c52cecff18ab7b243b2b45df7bc0